### PR TITLE
 Seller can specify local delivery available

### DIFF
--- a/Bangazon/Bangazon.csproj
+++ b/Bangazon/Bangazon.csproj
@@ -6,6 +6,13 @@
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Remove="NewFolder\**" />
+    <Content Remove="NewFolder\**" />
+    <EmbeddedResource Remove="NewFolder\**" />
+    <None Remove="NewFolder\**" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.3" />
@@ -19,6 +26,11 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.3" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Folder Include="Views\NewFolder\" />
   </ItemGroup>
 
 </Project>

--- a/Bangazon/Controllers/HomeController.cs
+++ b/Bangazon/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿    using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -32,7 +32,7 @@ namespace Bangazon.Controllers
         }
 
         // GET: Products/Details/5
-        public async  Task<ActionResult> Details(int id)
+        public async Task<ActionResult> Details(int id)
         {
             var product = await _context.Product.FirstOrDefaultAsync(p => p.ProductId == id);
             var viewModel = new ProductDetailViewModel()
@@ -49,7 +49,7 @@ namespace Bangazon.Controllers
         public async Task<ActionResult> Create()
         {
             var productTypes = await _context.ProductType
-                .Select(p => new SelectListItem() { Text = p.Label, Value = p.ProductTypeId.ToString()})
+                .Select(p => new SelectListItem() { Text = p.Label, Value = p.ProductTypeId.ToString() })
                 .ToListAsync();
             var viewmodel = new ProductFormViewModel();
             viewmodel.ProductTypeOptions = productTypes;
@@ -73,10 +73,15 @@ namespace Bangazon.Controllers
                     Description = productViewModel.Description,
                     UserId = user.Id,
                     Quantity = productViewModel.Quantity,
-                    ProductTypeId = productViewModel.ProductTypeId
+                    ProductTypeId = productViewModel.ProductTypeId,
+                    City = productViewModel.City
                 };
-             
 
+                if (productViewModel.LocalDelivery)
+                {
+                    product.City = productViewModel.City;
+                }
+          
                 _context.Product.Add(product);
                 await _context.SaveChangesAsync();
 
@@ -84,13 +89,13 @@ namespace Bangazon.Controllers
             }
             catch (Exception ex)
             {
-               var productTypes = await _context.ProductType
-                .Select(p => new SelectListItem() { Text = p.Label, Value = p.ProductTypeId.ToString() })
-                .ToListAsync();
+                var productTypes = await _context.ProductType
+                 .Select(p => new SelectListItem() { Text = p.Label, Value = p.ProductTypeId.ToString() })
+                 .ToListAsync();
                 productViewModel.ProductTypeOptions = productTypes;
                 ViewData["ErrorMessage"] = "Please Select a category.";
                 return View(productViewModel);
- 
+
             }
         }
 

--- a/Bangazon/Models/ProductViewModels/ProductFormViewModel.cs
+++ b/Bangazon/Models/ProductViewModels/ProductFormViewModel.cs
@@ -47,5 +47,7 @@ namespace Bangazon.Models.ProductViewModels
         [Required]
         public List<SelectListItem> ProductTypeOptions { get; set; }
 
+        public bool LocalDelivery { get; set; }
+
     }
 }

--- a/Bangazon/Views/Products/Create.cshtml
+++ b/Bangazon/Views/Products/Create.cshtml
@@ -5,7 +5,7 @@
 }
 @if (ViewData.ContainsKey("ErrorMessage"))
 {
-<div class="alert alert-danger">@ViewData["ErrorMessage"]</div>
+    <div class="alert alert-danger">@ViewData["ErrorMessage"]</div>
 }
 
 <h1>Create</h1>
@@ -46,6 +46,15 @@
                 <label asp-for="Quantity" class="control-label"></label>
                 <input asp-for="Quantity" class="form-control" />
                 <span asp-validation-for="Quantity" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="LocalDelivery">Is local delivery available?</label><br>
+                <input id="local-delivery-checkbox" asp-for="LocalDelivery" type="checkbox" class="form-control" value="true">
+            </div>
+            <div class="form-group hidden" id="city-input">
+                <label asp-for="City" class="control-label"></label>
+                <input asp-for="City" class="form-control" />
+                <span asp-validation-for="City" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />

--- a/Bangazon/wwwroot/css/site.css
+++ b/Bangazon/wwwroot/css/site.css
@@ -54,3 +54,8 @@ body {
   height: 60px;
   line-height: 60px; /* Vertically center the text there */
 }
+
+.hidden
+{
+    visibility: hidden;
+}

--- a/Bangazon/wwwroot/css/site.css
+++ b/Bangazon/wwwroot/css/site.css
@@ -57,5 +57,5 @@ body {
 
 .hidden
 {
-    visibility: hidden;
+    display: none;
 }

--- a/Bangazon/wwwroot/js/site.js
+++ b/Bangazon/wwwroot/js/site.js
@@ -2,3 +2,22 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+
+
+function clickListener() {
+    document.querySelector("#local-delivery-checkbox").addEventListener(
+        "click",
+        theClickEvent => {
+            const contentTarget = document.querySelector("#city-input")
+            if (contentTarget.classList.contains("hidden")) {
+                contentTarget.classList.remove("hidden")
+            }
+            else {
+                contentTarget.classList.add("hidden")
+            }
+        }
+    )
+}
+
+clickListener()


### PR DESCRIPTION
# Description

When users want to add a new product to sell, they can specify whether or not that product will be eligible for local delivery, and if so, what city it will be delivered in

Fixes #3 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

1. Click on 'Sell A Product' on the nav bar.
2. Fill out all necessary info and click on the checkbox for 'Is local delivery available?'
3. Confirm that clicking the checkbox revealed the city input
4. Unclick the 'Is local delivery available?' checkbox and confirm that the city input is hidden once again.
5. Reclick the 'Is local delivery available?' checkbox, add a city, and submit.
6. Check your Product table to confirm that the new product has a city
7. Add another product but leave 'Is local delivery available?' unchecked
8.  Check the Product table and confirm that the 2nd new product does not have a city


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
